### PR TITLE
add mixed content note to Omeka installation guide

### DIFF
--- a/workflows/install-omeka.md
+++ b/workflows/install-omeka.md
@@ -13,3 +13,14 @@ Omeka and Neatline are written on the LAMP stack (Linux, Apache, MySQL, PHP), wh
  - Login credentials for a MySQL user and a clean database for the Omeka installation. If you don't already have a database user account, most commercial hosting providers provide access to point-and-click database administration tools like phpMyAdmin that make it possible to create databases and users.
 
 Once you're ready, head over to the [official Omeka documentation](http://omeka.org/codex/Installation).
+
+## Preventing Mixed Content Errors in HTTPS
+
+Omeka will attempt to detect which protocol (http or https) a site visitor is using so that it can use the same protocol in retrieving asset files like the ones Neatline provides. In certain hosting environments, Omeka may fail to detect the use of https, resulting in mixed content errors when the page tries to load Neatline assets over http. If you support https in your installation, you can avoid these errors by adding the following lines to the .htaccess file in your Omeka directory:
+
+```
+SetEnv HTTPS "on"
+<FilesMatch ".(eot|ttf|otf|woff)">
+	Header set Access-Control-Allow-Origin "*"
+</FilesMatch>
+```


### PR DESCRIPTION
### What does this PR do?
Adds a note to the Omeka installation guide on preventing mixed content errors that can occur with Neatline assets in certain production environments.

### What issues does it address?
Resolves https://github.com/scholarslab/Neatline/issues/406